### PR TITLE
修复用url pathComponents 解释的时候出现的bug

### DIFF
--- a/HHRouter/HHRouter.m
+++ b/HHRouter/HHRouter.m
@@ -180,7 +180,7 @@
     // filter out the app URL compontents.
     for (NSString* appUrlScheme in [self appUrlSchemes]) {
         if ([string hasPrefix:[NSString stringWithFormat:@"%@:", appUrlScheme]]) {
-            return [string substringFromIndex:appUrlScheme.length + 1];
+            return [string substringFromIndex:appUrlScheme.length + 2];
         }
     }
 


### PR DESCRIPTION
上次修改成用 [[NSURL URLWithString:route] pathComponents] 出现了一个bug....
NSSRL 和 NSString 的pathComponents 开头是2个"//" 的结果居然是不同的...@_@


 po [[NSURL URLWithString:@"//gamevideodetail/53f44b23aa590571d70c9ce2"] pathComponents]
<__NSArrayM 0xeb71230>(
/,
53f44b23aa590571d70c9ce2
)



po [[NSURL URLWithString:@"/gamevideodetail/53f44b23aa590571d70c9ce2"] pathComponents]
<__NSArrayM 0xd7eeae0>(
/,
gamevideodetail,
53f44b23aa590571d70c9ce2
)



po [@"/gamevideodetail/53f44b23aa590571d70c9ce2" pathComponents]
<__NSArrayM 0xd3521f0>(
/,
gamevideodetail,
53f44b23aa590571d70c9ce2
)


po [@"//gamevideodetail/53f44b23aa590571d70c9ce2" pathComponents]
<__NSArrayM 0xd38d6c0>(
/,
gamevideodetail,
53f44b23aa590571d70c9ce2
)