### PR TITLE
Incorrect route parsing

### DIFF
--- a/HHRouter/HHRouter.m
+++ b/HHRouter/HHRouter.m
@@ -167,8 +167,11 @@
 
 - (NSArray*)pathComponentsFromRoute:(NSString*)route
 {
+    if([[route substringToIndex:2] isEqualToString:@"//"]) {
+        route = [route substringFromIndex:1];
+    }
     NSMutableArray *pathComponents = [NSMutableArray array];
-    for (NSString *pathComponent in route.pathComponents) {
+    for (NSString *pathComponent in [[NSURL URLWithString:route] pathComponents]) {
         if ([pathComponent isEqualToString:@"/"]) continue;
         if ([[pathComponent substringToIndex:1] isEqualToString:@"?"]) break;
         [pathComponents addObject:pathComponent];

--- a/HHRouterExampleTests/HHRouterTests.m
+++ b/HHRouterExampleTests/HHRouterTests.m
@@ -77,14 +77,47 @@
 //        [[[HHRouter shared] matchController:@"hhrouter://user/1/"] class],
 //        [UserViewController class]);
 
-    UserViewController* userViewController = (UserViewController*)
-        [[HHRouter shared] matchController:@"/user/1/?a=b&c=d"];
+    UserViewController* userViewController;
+    
+    userViewController = (UserViewController*) [[HHRouter shared]
+                                                matchController:@"/user/1/?a=b&c=d"];
     XCTAssertEqualObjects(userViewController.params[@"route"],
                           @"/user/1/?a=b&c=d");
     XCTAssertEqualObjects(userViewController.params[@"userId"], @"1");
     XCTAssertEqualObjects(userViewController.params[@"a"], @"b");
     XCTAssertEqualObjects(userViewController.params[@"c"], @"d");
+    
+    // non-regression Tests for PR #9
+    userViewController = (UserViewController*) [[HHRouter shared]
+                                                matchController:@"hhrouter:/user/1/?a=b&c=d"];
+    XCTAssertEqualObjects(userViewController.params[@"userId"], @"1");
+    XCTAssertEqualObjects(userViewController.params[@"a"], @"b");
+    XCTAssertEqualObjects(userViewController.params[@"c"], @"d");
+    
+    userViewController = (UserViewController*) [[HHRouter shared]
+                                                matchController:@"hhrouter://user/1/?a=b&c=d"];
+    XCTAssertEqualObjects(userViewController.params[@"userId"], @"1");
+    XCTAssertEqualObjects(userViewController.params[@"a"], @"b");
+    XCTAssertEqualObjects(userViewController.params[@"c"], @"d");
 	
+    // Tests for PR #11
+    userViewController = (UserViewController*) [[HHRouter shared]
+                                                matchController:@"/user/1?a=b&c=d"];
+    XCTAssertEqualObjects(userViewController.params[@"userId"], @"1");
+    XCTAssertEqualObjects(userViewController.params[@"a"], @"b");
+    XCTAssertEqualObjects(userViewController.params[@"c"], @"d");
+    
+    userViewController = (UserViewController*) [[HHRouter shared]
+                                                matchController:@"hhrouter:/user/1?a=b&c=d"];
+    XCTAssertEqualObjects(userViewController.params[@"userId"], @"1");
+    XCTAssertEqualObjects(userViewController.params[@"a"], @"b");
+    XCTAssertEqualObjects(userViewController.params[@"c"], @"d");
+    
+    userViewController = (UserViewController*) [[HHRouter shared]
+                                                matchController:@"hhrouter://user/1?a=b&c=d"];
+    XCTAssertEqualObjects(userViewController.params[@"userId"], @"1");
+    XCTAssertEqualObjects(userViewController.params[@"a"], @"b");
+    XCTAssertEqualObjects(userViewController.params[@"c"], @"d");
 	
 	
 	[[HHRouter shared] map:@"/test/:someId/"


### PR DESCRIPTION
Found in test file HHRouterTests.m : 
```
[[HHRouter shared] map:@"/test/:someId/"
         toControllerClass:[StoryListViewController class]];
	
	UserViewController* userViewController1 = (UserViewController*)
	[[HHRouter shared] matchController:@"/test/7777777?aa=11&bb=22"];
	NSLog(@"%@", userViewController1.params);
```

in `[userViewController1.params objectForKey:@"someId"]` we expect **7777777**, 
but we get **7777777?aa=11&bb=22**. This bug was introduced in commit 0cdf01b864bb1ae9a39cd6cca2763f1bba5950a9 (PR #9)
