### PR TITLE
修复了router block 传参无效的问题

### DIFF
--- a/HHRouter/HHRouter.m
+++ b/HHRouter/HHRouter.m
@@ -72,15 +72,16 @@
 {
     NSDictionary* params = [self paramsInRoute:route];
     HHRouterBlock routerBlock = [params[@"block"] copy];
-    HHRouterBlock returnBlock = ^id(NSDictionary* aParams)
-    {
+    HHRouterBlock returnBlock = ^id(NSDictionary* aParams) {
         if (routerBlock) {
-            return routerBlock([params copy]);
-        }
-        return nil;
-    };
+            NSMutableDictionary *dic = [NSMutableDictionary dictionaryWithDictionary:params];
+            [dic addEntriesFromDictionary:aParams];
+            return routerBlock([NSDictionary dictionaryWithDictionary:dic].copy);
+    }
+    return nil;
+  };
 
-    return [returnBlock copy];
+  return [returnBlock copy];
 }
 
 - (id)callBlock:(NSString*)route
@@ -247,4 +248,3 @@ static char kAssociatedParamsObjectKey;
 }
 
 @end
-


### PR DESCRIPTION
当使用

  HHRouterBlock block = [[HHRouter shared] matchBlockMerege:@"/testurl"];

这种方式进行匹配时，得到了正确的block，然后通过block得到对象：

block(@{@"name": @"abc"})；

block(nil);

以上两种得到的结果没有区别，是因为在 matchBlock 的时候，并没有对aParams进行调用（但进行了预留）