### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 HHRouter
 =====
 [![Build Status](https://travis-ci.org/Huohua/HHRouter.png)](https://travis-ci.org/Huohua/HHRouter)
-[![Cocoapods](https://cocoapod-badges.herokuapp.com/v/HHRouter/badge.png)](http://cocoapods.org/?q=HHRouter)
+[![CocoaPods](https://cocoapod-badges.herokuapp.com/v/HHRouter/badge.png)](http://cocoapods.org/?q=HHRouter)
 
 Yet another URL Router for iOS. Clean, Fast & Flexible. Inspired by [ABRouter](https://github.com/aaronbrethorst/ABRouter) & [Routable iOS](https://github.com/usepropeller/routable-ios).
 


### PR DESCRIPTION

This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>

Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
